### PR TITLE
Revert "added scipt_name in the node script to run before running cmd npm run…"

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "start": "node ./bin/www",
-    "dev": "start http://localhost:4000 && nodemon ./bin/www",
+    "dev": "nodemon ./bin/www",
     "generate:doc": "node ./swagger-autogen.js",
     "prisma-migrate": "npx prisma migrate dev",
     "prisma-seed": "npx prisma db seed",


### PR DESCRIPTION
Reverts su-brat/cart-saas-backend#17 due to a use of unsupported cross script `start`.

Reason: 
- `start` command used in npm scripts does not work for OS other than Windows
- Lack of proper testing